### PR TITLE
fix: update PHPCS to 4.0 and add line length ignore for DefaultConfig

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php-http/guzzle7-adapter": "^1.1",
     "phpstan/phpstan": "^2.1",
     "phpunit/phpunit": "^11.5",
-    "squizlabs/php_codesniffer": "^3.11"
+    "squizlabs/php_codesniffer": "^4.0"
   },
   "autoload": {
     "psr-4": {

--- a/src/OEmbed/Config/DefaultConfig.php
+++ b/src/OEmbed/Config/DefaultConfig.php
@@ -1,10 +1,6 @@
 <?php
-
+// phpcs:disable Generic.Files.LineLength.TooLong
 declare(strict_types=1);
-
-/**
- * @codingStandardsIgnoreFile
- */
 
 namespace RicardoFiorani\OEmbed\Config;
 


### PR DESCRIPTION
## Summary
- Update squizlabs/php_codesniffer from ^3.11 to ^4.0
- Replace @codingStandardsIgnoreFile docblock with inline phpcs:disable comment for Generic.Files.LineLength.TooLong to fix PHPCS 4.0 compatibility

## Test plan
- [ ] Run `vendor/bin/phpcs --standard=psr2 src/` and verify no errors/warnings